### PR TITLE
[IOPID-635] : Magic Link Redirect

### DIFF
--- a/mock/mockoon_api.json
+++ b/mock/mockoon_api.json
@@ -942,7 +942,7 @@
       "responses": [
         {
           "uuid": "be219bcd-778c-4bc2-842f-9f8f9fc04ec8",
-          "body": "{\n  \"jwt\": \"\"\n}",
+          "body": "{\n  \"jwt\": \"eyJhbGciOiJSUzI1NiIsInR5cCI6IkpXVCIsImtpZCI6ImtleS1pZC1mb3IteW91ci1qd3Qta2V5In0.eyJlbWFpbCI6ImNpdHRhZGluYW56YWRpZ2l0YWxlQHRlYW1kaWdpdGFsZS5nb3Zlcm5vLml0IiwiZmFtaWx5X25hbWUiOiJSb3NzaSIsImZpc2NhbF9udW1iZXIiOiJJU1BYTkIzMlI4Mlk3NjZEIiwibmFtZSI6IkNhcmxhIiwic3BpZF9sZXZlbCI6Imh0dHBzOi8vd3d3LnNwaWQuZ292Lml0L1NwaWRMMiIsImZyb21fYWEiOmZhbHNlLCJsZXZlbCI6IkwyIiwiaWF0IjoxNjk0NDM5NTYxLCJleHAiOjE2OTQ0NDMxNjEsImF1ZCI6Imh0dHBzOi8vbG9jYWxob3N0IiwiaXNzIjoiU1BJRCIsImp0aSI6Il9lMGYzODUxNmQ0NzJmZjUwNmU0ZSJ9.AWbBCDBi0siGroOtdu5Oxy3Bt1MaAI4jc0Ty-rtmpgBR4pJzuimOfBdiAXtCF5Sw9zfHp4awnIeeOUACTpj1KxBkhaZnYdZwAbsv9tEGL20HSR0GTA7QRjXE8fR1qOz81yXpLDUG77slo1mGcx8xSTUqBHl3z4gH9QZqcRh5nvcFkB691unSJ4p1fO3fMTT_XWGEX5XbiOcWkh3nV8fB2BSG-MaaKi3_CQeSD6WrPi5aWfWcsoY9RnaEAhUTfeqUnZxRNm623dxhun6SQbVajQnhFLnGlWFYaPgSqah3TyTGEgBZbmb0k71ESjvQqXK3xfLvaRQdY8QAeuTiiKlUHA\"\n}",
           "latency": 0,
           "statusCode": 200,
           "label": "Success",

--- a/src/app/[locale]/(pages)/blocco-accesso/magic-link/page.tsx
+++ b/src/app/[locale]/(pages)/blocco-accesso/magic-link/page.tsx
@@ -1,11 +1,46 @@
 'use client';
 import { Button, Grid, Typography } from '@mui/material';
 import { useTranslations } from 'next-intl';
+import { useEffect } from 'react';
 import { COMMON_PADDING_HERO } from '../../../_utils/styles';
 import HourglassIcon from '../../../_icons/hourglass';
+import { extractToken, userFromJwtToken } from '@/app/[locale]/_utils/jwt';
+import { isBrowser } from '@/app/[locale]/_utils/common';
+import { WebProfileApi } from '@/api/webProfileApiClient';
+import useLocalePush from '@/app/[locale]/_hooks/useLocalePush';
+import { ROUTES } from '@/app/[locale]/_utils/routes';
+import { storageTokenOps, storageUserOps } from '@/app/[locale]/_utils/storage';
 
 const ExpiredMagicLink = () => {
+  const token = isBrowser() ? extractToken() : undefined;
   const t = useTranslations('ioesco');
+  const pushWithLocale = useLocalePush();
+
+  useEffect(() => {
+    if (!token) {
+      pushWithLocale(ROUTES.INTERNAL_ERROR);
+    } else {
+      storageTokenOps.write(token);
+    }
+  }, [pushWithLocale, token]);
+
+  const handleContinue = () => {
+    if (token) {
+      WebProfileApi.exchangeToken()
+        .then((res) => {
+          if (res.jwt) {
+            storageTokenOps.write(res.jwt);
+            storageUserOps.write(userFromJwtToken(res.jwt));
+            pushWithLocale(ROUTES.PROFILE_BLOCK);
+          }
+        })
+        .catch(() => {
+          pushWithLocale(ROUTES.EXPIRED_MAGIC_LINK);
+        });
+    } else {
+      pushWithLocale(ROUTES.INTERNAL_ERROR);
+    }
+  };
 
   return (
     <Grid sx={COMMON_PADDING_HERO} container bgcolor="background.default">
@@ -46,7 +81,7 @@ const ExpiredMagicLink = () => {
           </Grid>
           <Grid item xs={12} textAlign={'center'}>
             <Grid display={'flex'} justifyContent="center">
-              <Button variant={'contained'}>
+              <Button variant={'contained'} onClick={() => handleContinue()}>
                 {
                   // FIXME: https://pagopa.atlassian.net/browse/IOPID-717
                   'Continua'


### PR DESCRIPTION

## Short description
Added the call to the backend to exchange the token from the URL link with the one generated by the /exchange handler.

## List of changes proposed in this pull request
- Added a call to /exchange when the button is clicked.
- Redirect to the profile blocked page on success.
- Redirect to an error page or expired link page in case of an error.

## How to test
Run the project.

**First.**
Access the magic link page from this link: http://localhost:3000/it/blocco-accesso/magic-link#token=dummytoken
PS. The magic link token is sent and validated by the backend.

Click on "Continua."
Visualize the blocked access page.
Verify if the token in session storage is updated

**Second.**
Simulate an error (500 or 401) on the mockoon EP /exchange.
Repeat the operation, but this time, you should see the expired/invalid link page.





