### PR TITLE
[IOPID-909] : Support Mailto

### DIFF
--- a/src/app/[locale]/_component/header/header.tsx
+++ b/src/app/[locale]/_component/header/header.tsx
@@ -8,7 +8,7 @@ import { usePathname } from 'next-intl/client';
 import useLogin from '../../_hooks/useLogin';
 import useLocalePush from '../../_hooks/useLocalePush';
 import { ROUTES } from '../../_utils/routes';
-import { isBrowser } from '../../_utils/common';
+import { decodeObfuschedEmail, isBrowser } from '../../_utils/common';
 import { initAnalytics, trackEvent } from '../../_utils/mixpanel';
 
 const Header = (): React.ReactElement => {
@@ -17,7 +17,10 @@ const Header = (): React.ReactElement => {
   const pushWithLocale = useLocalePush();
   const JWT_SPID_LEVEL_L1 = process.env.NEXT_PUBLIC_JWT_SPID_LEVEL_VALUE_L1;
   const pathName = usePathname();
+  const encodedEmail =
+    '&#@!105;&#@!111;&#@!64;assi%73ten&#@!37;7&#@!65;a&#@!46;&#@!112;%&#@!54;&#@!49;g&#@!111;p%6&#@!49;%&#@!50;&#@!69;it';
 
+  const email = decodeObfuschedEmail(encodedEmail);
   // eslint-disable-next-line react-hooks/exhaustive-deps
   const userMenuActionsBasic = [
     {
@@ -82,8 +85,7 @@ const Header = (): React.ReactElement => {
             : false
         }
         onAssistanceClick={(): void => {
-          // eslint-disable-next-line no-console
-          console.log('Clicked/Tapped on Assistance');
+          window.location.assign(`mailto:${email}`);
         }}
         onLogin={(): void => {
           // eslint-disable-next-line no-console

--- a/src/app/[locale]/_component/header/header.tsx
+++ b/src/app/[locale]/_component/header/header.tsx
@@ -8,7 +8,7 @@ import { usePathname } from 'next-intl/client';
 import useLogin from '../../_hooks/useLogin';
 import useLocalePush from '../../_hooks/useLocalePush';
 import { ROUTES } from '../../_utils/routes';
-import { decodeObfuschedEmail, isBrowser } from '../../_utils/common';
+import { decodeObfuscatedEmail, isBrowser } from '../../_utils/common';
 import { initAnalytics, trackEvent } from '../../_utils/mixpanel';
 
 const Header = (): React.ReactElement => {
@@ -20,7 +20,7 @@ const Header = (): React.ReactElement => {
   const encodedEmail =
     '&#@!105;&#@!111;&#@!64;assi%73ten&#@!37;7&#@!65;a&#@!46;&#@!112;%&#@!54;&#@!49;g&#@!111;p%6&#@!49;%&#@!50;&#@!69;it';
 
-  const email = decodeObfuschedEmail(encodedEmail);
+  const email = decodeObfuscatedEmail(encodedEmail);
   // eslint-disable-next-line react-hooks/exhaustive-deps
   const userMenuActionsBasic = [
     {

--- a/src/app/[locale]/_utils/common.ts
+++ b/src/app/[locale]/_utils/common.ts
@@ -49,3 +49,8 @@ export const getReferralLockProfile = (isMagicLink: MagicLink): string => {
     return 'profile';
   }
 };
+
+export const decodeObfuschedEmail = (encodedEmail: string): string =>
+  encodedEmail.replace(/&#@!(\d+);/g, function (match, dec) {
+    return String.fromCharCode(dec);
+  });

--- a/src/app/[locale]/_utils/common.ts
+++ b/src/app/[locale]/_utils/common.ts
@@ -50,7 +50,7 @@ export const getReferralLockProfile = (isMagicLink: MagicLink): string => {
   }
 };
 
-export const decodeObfuschedEmail = (encodedEmail: string): string =>
+export const decodeObfuscatedEmail = (encodedEmail: string): string =>
   encodedEmail.replace(/&#@!(\d+);/g, function (match, dec) {
     return String.fromCharCode(dec);
   });


### PR DESCRIPTION
## Short Description
"Mailto" Support Button

## How to Test
Log in (The support button is available only when the user is logged in).
Click on the Support Button in the Header, it should open the default email client with the sender's email set to io@assistenza.pagopa.it.
## Note:
The email address is obfuscated to "prevent" crawlers and bots from obtaining the email.