### PR TITLE
[IOPID-941] : Session Provider Refactoring

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "scripts": {
     "dev": "next dev",
     "build": "copy .env .env.local && next build",
-    "build:prod": "next build",
+    "build:prod": "next build && cp -r out/it/404/index.html out/it/404/index.txt out/404/ ",
     "start": "next start",
     "start-static": "npx serve@latest out",
     "test": "jest",

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "scripts": {
     "dev": "next dev",
     "build": "copy .env .env.local && next build",
-    "build:prod": "next build && cp -r out/it/404/index.html out/it/404/index.txt out/404/ ",
+    "build:prod": "next build && cp -f out/it/404/{index.html,index.txt} out/404/ && cp -f out/it/404/index.html out/404.html && cp -f out/it/404/index.txt out/404.txt",
     "start": "next start",
     "start-static": "npx serve@latest out",
     "test": "jest",

--- a/src/app/[locale]/_component/sessionProvider.tsx
+++ b/src/app/[locale]/_component/sessionProvider.tsx
@@ -10,7 +10,7 @@ import {
   EXISTING_ROUTES,
   LOGIN_ROUTES,
   PRIVATE_ROUTES,
-  PUBBLIC_ROUTES,
+  PUBLIC_ROUTES,
   ROUTES,
 } from '../_utils/routes';
 import { storageLocaleOps } from '../_utils/storage';
@@ -49,7 +49,7 @@ const SessionProviderComponent = ({ children }: { readonly children: React.React
         if (LOGIN_ROUTES.includes(pathName)) {
           removeToken();
         }
-        if (PUBBLIC_ROUTES.includes(pathName)) {
+        if (PUBLIC_ROUTES.includes(pathName)) {
           setLoginStatus({ status: 'AUTHORIZED' });
         }
         if (PRIVATE_ROUTES.includes(pathName)) {

--- a/src/app/[locale]/_component/sessionProvider.tsx
+++ b/src/app/[locale]/_component/sessionProvider.tsx
@@ -1,12 +1,20 @@
 'use client';
+import { useRouter } from 'next-intl/client';
 
 import { useLocale } from 'next-intl';
 import { usePathname } from 'next-intl/client';
 import { useEffect, useState } from 'react';
 import useLocalePush from '../_hooks/useLocalePush';
 import useToken from '../_hooks/useToken';
-import { LOGIN_ROUTES, PUBBLIC_ROUTES, ROUTES } from '../_utils/routes';
+import {
+  EXISTING_ROUTES,
+  LOGIN_ROUTES,
+  PRIVATE_ROUTES,
+  PUBBLIC_ROUTES,
+  ROUTES,
+} from '../_utils/routes';
 import { storageLocaleOps } from '../_utils/storage';
+import { defaultLocale, localeList } from '../layout';
 import Loader from './loader/loader';
 
 type LoginStatusIdle = {
@@ -29,28 +37,36 @@ const SessionProviderComponent = ({ children }: { readonly children: React.React
   const pushWithLocale = useLocalePush();
   const pathName = usePathname();
   const locale = useLocale();
+  const router = useRouter();
 
+  // eslint-disable-next-line sonarjs/cognitive-complexity
   useEffect(() => {
-    if (!storageLocaleOps.read()) {
-      storageLocaleOps.write(locale);
+    if (localeList.includes(locale)) {
+      if (!storageLocaleOps.read()) {
+        storageLocaleOps.write(locale);
+      }
+      if (EXISTING_ROUTES.includes(pathName)) {
+        if (LOGIN_ROUTES.includes(pathName)) {
+          removeToken();
+        }
+        if (PUBBLIC_ROUTES.includes(pathName)) {
+          setLoginStatus({ status: 'AUTHORIZED' });
+        }
+        if (PRIVATE_ROUTES.includes(pathName)) {
+          if (isTokenValid()) {
+            setLoginStatus({ status: 'AUTHORIZED' });
+          } else {
+            setLoginStatus({ status: 'NOT_AUTHORIZED' });
+            pushWithLocale(ROUTES.LOGIN);
+          }
+        }
+      } else {
+        pushWithLocale(ROUTES.NOT_FOUND_PAGE);
+      }
+    } else {
+      router.push(ROUTES.NOT_FOUND_PAGE, { locale: defaultLocale });
     }
-  }, [locale]);
-
-  useEffect(() => {
-    if (LOGIN_ROUTES.includes(pathName)) {
-      removeToken();
-    }
-    if (PUBBLIC_ROUTES.includes(pathName)) {
-      setLoginStatus({ status: 'AUTHORIZED' });
-    }
-    if (!PUBBLIC_ROUTES.includes(pathName) && isTokenValid()) {
-      setLoginStatus({ status: 'AUTHORIZED' });
-    }
-    if (!PUBBLIC_ROUTES.includes(pathName) && !isTokenValid()) {
-      setLoginStatus({ status: 'NOT_AUTHORIZED' });
-      pushWithLocale(ROUTES.LOGIN);
-    }
-  }, [pathName]);
+  }, [locale, pathName]);
 
   if (loginStatus.status === 'IDLE' || loginStatus.status === 'NOT_AUTHORIZED') {
     return <Loader />;

--- a/src/app/[locale]/_utils/routes.ts
+++ b/src/app/[locale]/_utils/routes.ts
@@ -35,3 +35,5 @@ export const PUBBLIC_ROUTES = [
 ];
 
 export const LOGIN_ROUTES = [ROUTES.LOGIN, ROUTES.LOGOUT_INIT];
+
+export const PRIVATE_ROUTES = EXISTING_ROUTES.filter((route) => !PUBBLIC_ROUTES.includes(route));

--- a/src/app/[locale]/_utils/routes.ts
+++ b/src/app/[locale]/_utils/routes.ts
@@ -24,7 +24,7 @@ export const ROUTES = {
 // Get an array of values from the ROUTES object
 export const EXISTING_ROUTES: string[] = Object.values(ROUTES);
 
-export const PUBBLIC_ROUTES = [
+export const PUBLIC_ROUTES = [
   ROUTES.LOGIN,
   ROUTES.LOGOUT_INIT,
   ROUTES.ERROR,
@@ -36,4 +36,4 @@ export const PUBBLIC_ROUTES = [
 
 export const LOGIN_ROUTES = [ROUTES.LOGIN, ROUTES.LOGOUT_INIT];
 
-export const PRIVATE_ROUTES = EXISTING_ROUTES.filter((route) => !PUBBLIC_ROUTES.includes(route));
+export const PRIVATE_ROUTES = EXISTING_ROUTES.filter((route) => !PUBLIC_ROUTES.includes(route));

--- a/src/app/[locale]/layout.tsx
+++ b/src/app/[locale]/layout.tsx
@@ -1,25 +1,27 @@
 import { NextIntlClientProvider } from 'next-intl';
-import { notFound } from 'next/navigation';
 import { ReactNode } from 'react';
+import SessionProviderComponent from '../[locale]/_component/sessionProvider';
 import Footer from './_component/footer/footer';
 import Header from './_component/header/header';
-import SessionProviderComponent from './_component/sessionProvider';
 import ThemeProviderComponent from './_component/themeProvider/themeProvider';
 import { Providers } from './_redux/provider';
+
+export const localeList = ['it'];
+export const defaultLocale = 'it';
 
 type Props = {
   children: ReactNode;
   params: { locale: string };
 };
 export async function generateStaticParams() {
-  return ['it'].map((locale) => ({ locale }));
+  return localeList.map((locale) => ({ locale }));
 }
 
 async function getMessages(locale: string) {
   try {
     return (await import(`../../dictionaries/${locale}.json`)).default;
   } catch (error) {
-    notFound();
+    return (await import(`../../dictionaries/${defaultLocale}.json`)).default;
   }
 }
 

--- a/src/dictionaries/en.json
+++ b/src/dictionaries/en.json
@@ -1,7 +1,0 @@
-{
-  "ioesco": {
-    "common": {
-      "hello": "Hello {nome}!" 
-      }
-      }
-    }


### PR DESCRIPTION
# Short Description
After the deployment, we noticed two issues.
- When attempting to change the locale from the URL route, it generated a redirect loop to **/ac**.
- The 404 page generated for static export of the website was the default one from Next.js and not the custom one.

👀 Please refer to this issue (regarding 404) at the following [link](https://github.com/vercel/next.js/issues/48227)

# List of Proposed Changes in this Pull Request
- The 404 page is being overwritten by the build script.
- Refactoring of the session provider component.
- Fixes on layout

# How to Test


1. yarn run build:prod
2. yarn run start-static

## First Scenario:

1. Go to localhost:3000
**2. You should expect to be redirected to /it/accedi (in local storage, you should have the 'it' locale)**

## Second Scenario:

1. Delete all data from local storage
2. Go to localhost:3000/pl (or whatever locale)
**3. You should expect to be redirected to the 404 page**

## Third Scenario:

1. Go to localhost:3000/it/whatever
**2. You should expect to be redirected to the 404 page**

## Fourth Scenario:
1. Adjust the callback URL for Hub SPID Login to match the trailing slash accordingly.
`ENDPOINT_ERROR=http://localhost:3000/it/accedi/errore/`
`ENDPOINT_SUCCESS=http://localhost:3000/it/accedi/`

3. Try to log in with Hub SPID login
**3. Check if, after login, you will see the profile page accordingly**

## Fifth Scenario:

1. When you are logged in
2. Go to localhost:3000/it/whatever
**3. You should expect to be redirected to the 404 page**