### PR TITLE
[IOPID-979] : Adding Profile Already Locked Page (Magic Link)

### DIFF
--- a/src/app/[locale]/(pages)/accesso-bloccato/page.tsx
+++ b/src/app/[locale]/(pages)/accesso-bloccato/page.tsx
@@ -1,0 +1,45 @@
+'use client';
+
+import { Grid, Link } from '@mui/material';
+import { useTranslations } from 'next-intl';
+import { FeedbackMessage } from '../../_component/feedbackMessage/feedbackMessage';
+import { commonBackground } from '../../_utils/styles';
+import { storageLocaleOps } from '../../_utils/storage';
+import Firework from '@/app/[locale]/_icons/firework';
+import useLocalePush from '@/app/[locale]/_hooks/useLocalePush';
+import { ROUTES } from '@/app/[locale]/_utils/routes';
+
+const AlreadyLocked = (): React.ReactElement => {
+  const t = useTranslations('ioesco');
+  const pushWithLocale = useLocalePush();
+  const baseUrl = window.location.origin;
+  const locale = storageLocaleOps.read() ? storageLocaleOps.read() : 'it';
+
+  const explanationrestorecodeRich = {
+    link: (chunks: React.ReactNode) => (
+      <Link href={`${baseUrl}/${locale}${ROUTES.LOGIN_L3}`} fontWeight={600}>
+        {chunks}
+      </Link>
+    ),
+    br: () => <br />,
+  };
+
+  return (
+    <Grid sx={commonBackground} container>
+      <Grid item xs={12} justifySelf={'center'}>
+        <FeedbackMessage
+          topIcon={<Firework />}
+          title={t('magiclink.errorlockedaccess')}
+          summary={t.rich('magiclink.errorlockedaccessl3', explanationrestorecodeRich)}
+          firstButton={{
+            onClick: () => pushWithLocale(ROUTES.PROFILE),
+            variant: 'contained',
+            text: t('common.backtoprofile'),
+          }}
+        />
+      </Grid>
+    </Grid>
+  );
+};
+
+export default AlreadyLocked;

--- a/src/app/[locale]/(pages)/blocco-accesso/magic-link/page.tsx
+++ b/src/app/[locale]/(pages)/blocco-accesso/magic-link/page.tsx
@@ -36,8 +36,20 @@ const ExpiredMagicLink = () => {
           if (res.jwt) {
             storageTokenOps.write(res.jwt);
             storageUserOps.write(userFromJwtToken(res.jwt));
-            pushWithLocale(ROUTES.PROFILE_BLOCK);
           }
+        })
+        .then(() => {
+          WebProfileApi.getUserSessionState()
+            .then((res) => {
+              if (!res.access_enabled) {
+                pushWithLocale(ROUTES.ALREADY_LOCKED);
+              } else {
+                pushWithLocale(ROUTES.PROFILE_BLOCK);
+              }
+            })
+            .catch(() => {
+              pushWithLocale(ROUTES.INTERNAL_ERROR);
+            });
         })
         .catch(() => {
           pushWithLocale(ROUTES.EXPIRED_MAGIC_LINK);

--- a/src/app/[locale]/_component/feedbackMessage/feedbackMessage.tsx
+++ b/src/app/[locale]/_component/feedbackMessage/feedbackMessage.tsx
@@ -13,7 +13,7 @@ type CustomMaterialButtonProps = {
 type IntroductionProps = {
   topIcon?: JSX.Element;
   title: string;
-  summary: string | JSX.Element;
+  summary: string | JSX.Element | React.ReactNode;
   firstButton: CustomMaterialButtonProps;
   secondButton?: CustomMaterialButtonProps;
 };

--- a/src/app/[locale]/_utils/routes.ts
+++ b/src/app/[locale]/_utils/routes.ts
@@ -18,6 +18,7 @@ export const ROUTES = {
   ERROR: '/accedi/errore/',
   EXPIRED_MAGIC_LINK: '/blocco-accesso/link-scaduto/',
   MAGIC_LINK: '/blocco-accesso/magic-link/',
+  ALREADY_LOCKED: '/accesso-bloccato/',
   NOT_FOUND_PAGE: '/404/',
   INTERNAL_ERROR: '/500/',
 };

--- a/src/dictionaries/it.json
+++ b/src/dictionaries/it.json
@@ -181,7 +181,7 @@
     "lplogoutpostlogin": {
       "activesession": "Al momento hai una sessione attiva sull’app IO con <strong>{deviceModel}</strong>. Se hai perso il dispositivo o non lo riconosci, termina la sessione. Potrai poi accedere nuovamente da qualsiasi altro dispositivo.",
       "lastdateactivation": "Sessione valida fino al {date}",
-      "noactivesession": "Al momento non hai attiva nessuna sessione su IO. Se non hai più il tuo dispositivo i tuoi dati sono al sicuro. \nPuoi accedere nuovamente con le tue credenziali SPID o CIE da qualsiasi dispositivo."
+      "noactivesession": "Al momento non hai nessuna sessione attiva. Anche se non hai più il tuo dispositivo, le informazioni su IO sono al sicuro. \nPuoi accedere nuovamente con le tue credenziali SPID o CIE da qualsiasi dispositivo."
     },
     "profile": {
       "activesession": "Sessione attiva in app",
@@ -205,8 +205,7 @@
       "notvalidcode": "Codice non valido, controlla e riprova",
       "restorecodecopied": "Codice di ripristino copiato",
       "restoredaccess": "Accesso ripristinato",
-      "unlockaccessl2": "Sblocca l’accesso con livello 2",
-      "unlockl3app": "Se hai bloccato l’accesso a IO con il livello di sicurezza 3, ripristina l’accesso all’app. ",
+      "unlockl3app": "Per poter usare l'app, devi prima sbloccare l'accesso a IO. ",
       "whatisl3": "Cos’è un’identità di livello 3?",
       "login": "Se hai bloccato l’accesso all’app IO per ragioni di sicurezza, ripristina l’accesso seguendo le indicazioni.\n\nQui trovi le identità digitali che hai utilizzato per entrare su IO e verificare se sono abilitate. ",
       "restoreprofile": "Sblocca l’accesso",
@@ -214,7 +213,7 @@
       "restoreaccess": "Vuoi sbloccare l’accesso a IO?"
     },
     "thankyoupage": {
-      "accesslocked": "D’ora in poi potrai entrare solo con la tua identità digitale con un livello di sicurezza 3.\n\nIn alternativa, puoi sbloccare l’accesso all’app attraverso questo codice di ripristino. Salvalo e tienilo al sicuro!",
+      "accesslocked": "D’ora in poi potrai entrare solo con la tua identità digitale con un <link>livello di sicurezza 3</link>. <br></br>In alternativa, puoi sbloccare l’accesso all’app attraverso questo codice di ripristino. Salvalo e tienilo al sicuro!",
       "enterbackio": "Per entrare nuovamente in app IO, ti basterà accedere con le tue credenziali SPID o CIE da qualsiasi dispositivo.",
       "enterbackonio": "Per entrare nuovamente in app IO, ti basterà accedere con le tue credenziali SPID o CIE da qualsiasi dispositivo."
     },
@@ -224,7 +223,9 @@
       "nosession": "Non c’è nessuna sessione di IO attiva"
     },
     "magiclink": {
-      "restore": "Se vuoi ripristinare l’accesso all’app IO, accedi con le tue credenziali SPID o CIE e segui i passaggi indicati."
-     }
+      "restore": "Se vuoi ripristinare l’accesso all’app IO, accedi con le tue credenziali SPID o CIE e segui i passaggi indicati.",
+      "errorlockedaccess": "L’accesso a IO è già bloccato",
+      "errorlockedaccessl3": "Puoi entrare in app solo con la tua identità digitale con un <link>livello di sicurezza 3</link>."
+    }
   }
 }


### PR DESCRIPTION
# Short Description

Handling the case where the profile is already locked, but access is still attempted via a magic link, the already locked  page will be displayed.

# List of Proposed Changes in this Pull Request

1. Added a new page "Access Already Locked." [FIGMA](https://www.figma.com/file/2BZhyc0qxN31sF6npvbeTh/IO-Esco?type=design&node-id=4602-30178&mode=design&t=3pidQBPpobxBz95W-4)
2. Updated the Italian dictionary file (DITTO).

# How to Test

1. Set up a mock **/session-state** endpoint with the following response body:

   ```json
   {
     "access_enabled": false,
     "session_info": {
       "active": true,
       "expiration_date": "2025-10-13"
     }
   }
2. Run the project and log in using the magic-link (http://localhost:3000/it/blocco-accesso/magic-link/#token=token)
3. When you land on the magic link page, click on continue button to exchange the token.
6. **You should expect to see the new page "Profile Already Locked"**

## Lastly

If you set the response on **/session-state**:

   ```json
   {
     "access_enabled": true,
     "session_info": {
       "active": true,
       "expiration_date": "2025-10-13"
     }
   }
```

and you repeat the sequence from point 2, you should see the normal magic link flow.
