### PR TITLE
[IOPID-1220] Fix error on login using cie

### DIFF
--- a/src/app/[locale]/_utils/idps.ts
+++ b/src/app/[locale]/_utils/idps.ts
@@ -1,4 +1,6 @@
+import { SpidLevels } from '../_component/selectIdp/idpList';
 import { isEnvConfigEnabled } from './common';
+import { storageLoginInfoOps } from './storage';
 
 export type IdentityProvider = {
   identifier: string;
@@ -120,16 +122,16 @@ export { IDPS };
 // TODO remove this temporary flag isIdpKnownafter getSessionsList API is ready in a future version
 export const isIdpKnown = (): boolean => process.env.NEXT_PUBLIC_FEATURE_FLAG === 'true';
 
-export const goCIE = (spidLevel: string) => {
+export const goCIE = (spidLevel: SpidLevels) => {
   // MANDATORY !!
   // FIX ME WHEN CIE WILL BE AVAILABLE
   // MISSING LOGIN INFO ON loginInfo VAR for MIXPANEL LOGIN TECH EVENT
   //
-  // storageLoginInfoOps.write({
-  //   idpId: 'CIE',
-  //   idpName: 'CIE',
-  //   idpSecurityLevel: spidLevel,
-  // });
+  storageLoginInfoOps.write({
+    idpId: 'cie',
+    idpName: 'CIE',
+    idpSecurityLevel: spidLevel,
+  });
   window.location.assign(
     `${process.env.NEXT_PUBLIC_URL_SPID_LOGIN}?entityID=${process.env.NEXT_PUBLIC_SPID_CIE_ENTITY_ID}&authLevel=Spid${spidLevel}&RelayState=ioapp`
   );


### PR DESCRIPTION
## Short description
There was an error due to the integration of CIE because within the code, the part where the CIE information was recorded in the local storage was commented out. Once uncommented and changed the values to pass the correct ones, it should work correctly. 

![image](https://github.com/pagopa/io-web-profile/assets/83651704/63efffc7-0edb-4c08-900f-ba946f88fdaf)


## List of changes proposed in this pull request

- Decomment code to pass the informations about CIE.
- Fix information about CIE stored in session storage 

## How to test

When CIE login is chosen in the login screens, make sure that the CIE information is correctly entered in the local storage within the loginInfo object (as you can see from the image below) 
<img width="763" alt="Screenshot 2023-12-07 alle 11 07 49" src="https://github.com/pagopa/io-web-profile/assets/83651704/c1e10026-6b7f-4563-a9bd-740912d0019a">
