### PR TITLE
[IOPID-1169] : Mixpanel Error TrackEvent

### DIFF
--- a/src/app/[locale]/(pages)/ripristino-accesso/errore/page.tsx
+++ b/src/app/[locale]/(pages)/ripristino-accesso/errore/page.tsx
@@ -13,11 +13,14 @@ const LoginKo = (): React.ReactElement => {
   const t = useTranslations('ioesco');
 
   useEffect(() => {
-    trackEvent('IO_PROFILE_UNLOCK_ACCESS_ERROR', { event_category: 'KO', reason: 'UNLOCK_ERROR' });
+    trackEvent('IO_PROFILE_UNLOCK_ACCESS_ERROR', { event_category: 'KO' });
   }, []);
 
   const handleRetryBtn = () => {
-    trackEvent('IO_PROFILE_LOCK_ACCESS_TRY_AGAIN', { event_category: 'UX', event_type: 'action' });
+    trackEvent('IO_PROFILE_UNLOCK_ACCESS_TRY_AGAIN', {
+      event_category: 'UX',
+      event_type: 'action',
+    });
   };
 
   return (


### PR DESCRIPTION
#  ⚠️ Depends on https://github.com/pagopa/io-web-profile/pull/104 ⚠️

## Short description

Traceability with Mixpanel was missing in the case of an error when entering the wrong unlock code. 
In fact, while performing the previous task IOPID-1250, we noticed that the events IO_PROFILE_LOCK_ACCESS_ERROR and IO_PROFILE_LOCK_ACCESS_TRY_AGAIN were never triggered. 
Therefore, traceability for these events has been added in blocco-accesso/errore as described [here](https://airtable.com/appiMMF1rPzZa9WXH/shrW019QD0kzDBRJW/tblgUedooVqZPi6Wr).

## How to test

Run the project and verify that the Mixpanel event is triggered on the 'blocco-accesso/errore' page. 
To reach that page, simulate to unlock your profile using an unlock code. 
(Remember to  mock the unlock-session API with a 500 response)