### PR TITLE
[IOPID-1218] : Fixxing Bug on 403 Case

### DIFF
--- a/src/api/webProfileApiClient.ts
+++ b/src/api/webProfileApiClient.ts
@@ -50,7 +50,7 @@ export async function callFetchWithRetries<
             return response.right.value;
           case 403:
             onRedirectToLogin();
-            throw new Error(`Operation not allowed!`);
+            return;
           case 404:
             return new Promise((resolve) => resolve(response.right.status));
           default:


### PR DESCRIPTION
## Short description

This PR is meant to fix a regression caused by the last development of the same task.
During testing, we noticed that an error was being thrown, forcing the application to catch the fetch call, leading to an undesired double page render.

## How to test

1. Run the project.
2. Log in and land on the profile page.
3. Set the response of the **sessionState** and **getProfile** calls to a 403.
4. Refresh the page.
5. We expect to be redirected to the login, clearing the storage.

**NB:** For the redirect, we are using the goToLogin() method, which has a default timeout of 5 seconds. 
To expedite the time between the trigger and the page redirect, the timeout could be reduced (if desired).
