### PR TITLE
[IOPID-1576] - Lock with L2 using magic link - 403

### DIFF
--- a/src/app/[locale]/(pages)/blocco-accesso/magic-link/page.tsx
+++ b/src/app/[locale]/(pages)/blocco-accesso/magic-link/page.tsx
@@ -28,7 +28,7 @@ const ExpiredMagicLink = () => {
       storageTokenOps.write(token);
       storageMagicLinkOps.write({ value: true });
     }
-  }, [pushWithLocale, token]);
+  }, [token]);
 
   const handleContinue = () => {
     setIsButtonDisabled(true);


### PR DESCRIPTION
## Short description
Remove dependency on magic.link page from the useEffect hook (pushWithLocale), as it triggers the useEffect twice, resulting in token overwriting.
