### PR TITLE
[SIW-1138] Fix wrong README statements

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ You can find the hub-spid-login project at this GitHub repository: https://githu
 To ensure proper execution of the service, please follow the documentation provided by hub-spid-login. Additionally, make the following modifications to the default values within the hub-spid-login .env file:
 
 ``ENDPOINT_ERROR=http://localhost:3000/accedi/errore``
-``ENDPOINT_SUCCESS=http://localhost:3000/it/accedi
+``ENDPOINT_SUCCESS=http://localhost:3000/it/accedi/
 ``
 ``
 ENABLE_JWT=true``
@@ -137,7 +137,7 @@ The application will be running in development mode, you can access it locally b
 yarn run build
 
 #to run build solution
-yarn run start
+yarn run start-static
 
 ```
 You can access the application in production mode by visiting: http://localhost:3000 in your web browser.


### PR DESCRIPTION
## Short description

These changes ensure that the documentation accurately reflects the necessary configurations and instructions for running the application.

## List of changes proposed in this pull request

This pull request fixes some incorrect statements in the README.md file. The changes include updating the `ENDPOINT_SUCCESS` value and modifying the command to start the application in production mode. 

## How to test

vim README