### PR TITLE
ci: [SIW-1412] remove sperimentation label in revoke flow

### DIFF
--- a/src/dictionaries/it.json
+++ b/src/dictionaries/it.json
@@ -169,7 +169,7 @@
     "lgdesktopdrawer": {
       "title": "Confermi di voler disattivare IT Wallet?",
       "back": "Torna indietro",
-      "description": "Tutti i documenti in versione digitale presenti nel tuo Portafoglio saranno disattivati in modo permanente. Inoltre, non riceverai più messaggi che riguardano la sperimentazione."
+      "description": "Tutti i documenti in versione digitale presenti nel tuo Portafoglio saranno disattivati in modo permanente."
     },
     "lockaccess": {
       "accessidentity": "Qui trovi le identità digitali che hai utilizzato per entrare su IO. Se non hai effettuato tu l’accesso, puoi bloccarlo e mantenere i tuoi dati al sicuro. ",


### PR DESCRIPTION
## Short description

Removed sperimentation label text from wallet instance revoke flow

## List of changes proposed in this pull request

- Hide a part of text in revoke confirmation dialog

## How to test

Try a revoke request flow in io-web, in confirmation dialog text must not contain this `Inoltre, non riceverai più messaggi che riguardano la sperimentazione.`
