### PR TITLE
[IOPID-2577] add identify call from mixpanel and fix existent init

### DIFF
--- a/src/app/[locale]/_component/sessionActiveComp/__tests__/sessionActiveCompENLocale.test.tsx
+++ b/src/app/[locale]/_component/sessionActiveComp/__tests__/sessionActiveCompENLocale.test.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 import { test, vi } from 'vitest';
 import SessionActiveComp from '../sessionActiveComp';
 import { renderWithProviders } from '@/app/[locale]/_utils/test-utils';
-import { localeFromStorage } from '@/app/[locale]/_utils/common';
+import { isBrowser, localeFromStorage } from '@/app/[locale]/_utils/common';
 
 vi.mock('../../../_component/accordion/faqDefault.tsx', () => ({
   FAQ: () => (
@@ -12,7 +12,11 @@ vi.mock('../../../_component/accordion/faqDefault.tsx', () => ({
   ),
 }));
 
-vi.mock('../../../_utils/common.ts', () => ({ localeFromStorage: 'en' }));
+vi.mock('../../../_utils/common.ts', () => ({
+  localeFromStorage: 'en',
+  isEnvConfigEnabled: (envVar: string | undefined) => envVar === 'true',
+  isBrowser: () => true,
+}));
 
 describe('Sanity Checks', () => {
   test("localeFromStorage should be 'en'", () => {

--- a/src/app/[locale]/_component/sessionActiveComp/__tests__/sessionActiveCompITLocale.test.tsx
+++ b/src/app/[locale]/_component/sessionActiveComp/__tests__/sessionActiveCompITLocale.test.tsx
@@ -12,7 +12,11 @@ vi.mock('../../../_component/accordion/faqDefault.tsx', () => ({
   ),
 }));
 
-vi.mock('../../../_utils/common.ts', () => ({ localeFromStorage: 'it' }));
+vi.mock('../../../_utils/common.ts', () => ({
+  localeFromStorage: 'it',
+  isEnvConfigEnabled: (envVar: string | undefined) => envVar === 'true',
+  isBrowser: () => true,
+}));
 
 describe('Sanity Checks', () => {
   test("localeFromStorage should be 'it'", () => {

--- a/src/app/[locale]/_utils/cookie-utils.ts
+++ b/src/app/[locale]/_utils/cookie-utils.ts
@@ -1,4 +1,5 @@
 import { CookieValueTypes, deleteCookie, getCookie, setCookie } from 'cookies-next';
+import { OptionsType } from 'cookies-next/lib/types';
 
 // eslint-disable-next-line @typescript-eslint/ban-types
 type CookieValue = string | object;
@@ -10,13 +11,18 @@ export function cookieDelete(key: string) {
 }
 
 /** Write value into cookie */
-export function cookieWrite(key: string, value: CookieValue, type: CookieValueType) {
+export function cookieWrite(
+  key: string,
+  value: CookieValue,
+  type: CookieValueType,
+  options?: OptionsType
+) {
   const stringifyFn: { [key in CookieValueType]: () => string } = {
     string: () => value as string,
     object: () => JSON.stringify(value),
   };
   const stringified = stringifyFn[type]();
-  setCookie(key, stringified);
+  setCookie(key, stringified, options);
 }
 
 /** Read value from cookie */

--- a/src/app/[locale]/_utils/mixpanel.ts
+++ b/src/app/[locale]/_utils/mixpanel.ts
@@ -15,6 +15,11 @@ const IS_SUBDOMAIN = isEnvConfigEnabled(process.env.NEXT_PUBLIC_IS_ACCOUNT_SUBDO
 
 type EventCategory = 'KO' | 'TECH' | 'UX';
 
+type windowMPValues = {
+  initMixPanel?: boolean;
+  mixPanelIdentify?: boolean;
+};
+
 type EventType =
   | 'action'
   | 'control'
@@ -32,7 +37,6 @@ export interface EventProperties {
 }
 
 /** To call in order to start the analytics service, otherwise no event will be sent */
-// eslint-disable-next-line sonarjs/cognitive-complexity
 export const initAnalytics = (): void => {
   if (ANALYTICS_ENABLE) {
     if (ANALYTICS_MOCK) {
@@ -40,7 +44,7 @@ export const initAnalytics = (): void => {
       console.log('Mixpanel events mock on console log.');
     } else {
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
-      if (isBrowser() && !(window as any).initMixPanel) {
+      if (isBrowser() && !(window as Window & windowMPValues).initMixPanel) {
         mixpanel.init(ANALYTICS_TOKEN, {
           api_host: ANALYTICS_API_HOST,
           persistence: ANALYTICS_PERSISTENCE as 'cookie' | 'localStorage',
@@ -48,24 +52,7 @@ export const initAnalytics = (): void => {
           debug: ANALYTICS_DEBUG,
         });
         // eslint-disable-next-line functional/immutable-data, @typescript-eslint/no-explicit-any
-        (window as any).initMixPanel = true;
-        // decomment only to make some tests
-        // const baseUrl = isBrowser() && window.location.origin;
-        // if (baseUrl === 'http://sub.localhost:3000') {
-        //   cookieWrite(
-        //     'device_id',
-        //     '19474d3c9bd23ad-0d6f3263d3123f-1e525636-1d73c0-19474d3c9bd23ad',
-        //     'string',
-        //     {
-        //       domain: '.localhost', // makes the cookie valid on the sub domains
-        //       path: '/', // makes the cookie valid for all pages
-        //       maxAge: 60 * 60 * 24 * 30, // cookie duration
-        //       secure: false, // if value is false "https" is NOT required
-        //       sameSite: 'none', // if "none" the cookie is available on all domains insert in "domain" value.
-        //                            Otherwise the cookie is available only on the current domain
-        //     }
-        //   );
-        // }
+        (window as Window & windowMPValues).initMixPanel = true;
       }
       /**
        * This ‘identify’ call is only made if the user
@@ -73,10 +60,10 @@ export const initAnalytics = (): void => {
        * Only in this case does it have the device_id in the cookies
        */
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
-      if (DEVICE_ID && IS_SUBDOMAIN && !(window as any).mixPanelIdentify) {
+      if (DEVICE_ID && IS_SUBDOMAIN && !(window as Window & windowMPValues).mixPanelIdentify) {
         mixpanel.identify(DEVICE_ID);
         // eslint-disable-next-line @typescript-eslint/no-explicit-any, functional/immutable-data
-        (window as any).mixPanelIdentify = true;
+        (window as Window & windowMPValues).mixPanelIdentify = true;
       }
     }
   }
@@ -95,7 +82,7 @@ export const trackEvent = (
   callback?: () => void
 ): void => {
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  if (ANALYTICS_ENABLE && (window as any).initMixPanel && hasConsent()) {
+  if (ANALYTICS_ENABLE && (window as Window & windowMPValues).initMixPanel && hasConsent()) {
     if (ANALYTICS_MOCK) {
       // eslint-disable-next-line no-console
       console.log(event_name, properties);

--- a/src/app/[locale]/_utils/mixpanel.ts
+++ b/src/app/[locale]/_utils/mixpanel.ts
@@ -43,7 +43,7 @@ export const initAnalytics = (): void => {
       // eslint-disable-next-line no-console
       console.log('Mixpanel events mock on console log.');
     } else {
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      // eslint-disable-next-line
       if (isBrowser() && !(window as Window & windowMPValues).initMixPanel) {
         mixpanel.init(ANALYTICS_TOKEN, {
           api_host: ANALYTICS_API_HOST,
@@ -51,7 +51,7 @@ export const initAnalytics = (): void => {
           ip: ANALYTICS_LOG_IP,
           debug: ANALYTICS_DEBUG,
         });
-        // eslint-disable-next-line functional/immutable-data, @typescript-eslint/no-explicit-any
+        // eslint-disable-next-line functional/immutable-data
         (window as Window & windowMPValues).initMixPanel = true;
       }
       /**
@@ -59,10 +59,10 @@ export const initAnalytics = (): void => {
        * is landing on the portal from the showcase site.
        * Only in this case does it have the device_id in the cookies
        */
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      // eslint-disable-next-line
       if (DEVICE_ID && IS_SUBDOMAIN && !(window as Window & windowMPValues).mixPanelIdentify) {
         mixpanel.identify(DEVICE_ID);
-        // eslint-disable-next-line @typescript-eslint/no-explicit-any, functional/immutable-data
+        // eslint-disable-next-line functional/immutable-data
         (window as Window & windowMPValues).mixPanelIdentify = true;
       }
     }
@@ -75,13 +75,13 @@ export const initAnalytics = (): void => {
  * @property properties: the additional payload sent with the event
  * @property callback: an action taken when the track has completed (If the action taken immediately after the track is an exit action from the application, it's better to use this callback to perform the exit, in order to give to mixPanel the time to send the event)
  */
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
+// eslint-disable-next-line
 export const trackEvent = (
   event_name: string,
   properties?: EventProperties,
   callback?: () => void
 ): void => {
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  // eslint-disable-next-line
   if (ANALYTICS_ENABLE && (window as Window & windowMPValues).initMixPanel && hasConsent()) {
     if (ANALYTICS_MOCK) {
       // eslint-disable-next-line no-console

--- a/src/app/[locale]/_utils/mixpanel.ts
+++ b/src/app/[locale]/_utils/mixpanel.ts
@@ -1,13 +1,17 @@
 import mixpanel from 'mixpanel-browser';
 import { hasConsent } from '../_hooks/useConsent';
+import { cookieRead } from './cookie-utils';
+import { isBrowser, isEnvConfigEnabled } from './common';
 
 const ANALYTICS_ENABLE = process.env.NEXT_PUBLIC_ANALYTICS_ENABLE;
-const ANALYTICS_MOCK = process.env.NEXT_PUBLIC_ANALYTICS_MOCK === 'true' ? true : false;
+const ANALYTICS_MOCK = isEnvConfigEnabled(process.env.NEXT_PUBLIC_ANALYTICS_MOCK);
 const ANALYTICS_TOKEN = process.env.NEXT_PUBLIC_ANALYTICS_TOKEN || '';
 const ANALYTICS_API_HOST = process.env.NEXT_PUBLIC_ANALYTICS_API_HOST;
 const ANALYTICS_PERSISTENCE = process.env.NEXT_PUBLIC_ANALYTICS_PERSISTENCE;
-const ANALYTICS_LOG_IP = process.env.NEXT_PUBLIC_ANALYTICS_LOG_IP === 'true' ? true : false;
-const ANALYTICS_DEBUG = process.env.NEXT_PUBLIC_ANALYTICS_DEBUG === 'true' ? true : false;
+const ANALYTICS_LOG_IP = isEnvConfigEnabled(process.env.NEXT_PUBLIC_ANALYTICS_LOG_IP);
+const ANALYTICS_DEBUG = isEnvConfigEnabled(process.env.NEXT_PUBLIC_ANALYTICS_DEBUG);
+const DEVICE_ID = isBrowser() && cookieRead('device_id', 'string');
+const IS_SUBDOMAIN = isEnvConfigEnabled(process.env.NEXT_PUBLIC_IS_ACCOUNT_SUBDOMAIN);
 
 type EventCategory = 'KO' | 'TECH' | 'UX';
 
@@ -28,20 +32,52 @@ export interface EventProperties {
 }
 
 /** To call in order to start the analytics service, otherwise no event will be sent */
+// eslint-disable-next-line sonarjs/cognitive-complexity
 export const initAnalytics = (): void => {
   if (ANALYTICS_ENABLE) {
-    // eslint-disable-next-line functional/immutable-data, @typescript-eslint/no-explicit-any
-    (window as any).initMixPanel = true;
     if (ANALYTICS_MOCK) {
       // eslint-disable-next-line no-console
       console.log('Mixpanel events mock on console log.');
     } else {
-      mixpanel.init(ANALYTICS_TOKEN, {
-        api_host: ANALYTICS_API_HOST,
-        persistence: ANALYTICS_PERSISTENCE as 'cookie' | 'localStorage',
-        ip: ANALYTICS_LOG_IP,
-        debug: ANALYTICS_DEBUG,
-      });
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      if (isBrowser() && !(window as any).initMixPanel) {
+        mixpanel.init(ANALYTICS_TOKEN, {
+          api_host: ANALYTICS_API_HOST,
+          persistence: ANALYTICS_PERSISTENCE as 'cookie' | 'localStorage',
+          ip: ANALYTICS_LOG_IP,
+          debug: ANALYTICS_DEBUG,
+        });
+        // eslint-disable-next-line functional/immutable-data, @typescript-eslint/no-explicit-any
+        (window as any).initMixPanel = true;
+        // decomment only to make some tests
+        // const baseUrl = isBrowser() && window.location.origin;
+        // if (baseUrl === 'http://sub.localhost:3000') {
+        //   cookieWrite(
+        //     'device_id',
+        //     '19474d3c9bd23ad-0d6f3263d3123f-1e525636-1d73c0-19474d3c9bd23ad',
+        //     'string',
+        //     {
+        //       domain: '.localhost', // makes the cookie valid on the sub domains
+        //       path: '/', // makes the cookie valid for all pages
+        //       maxAge: 60 * 60 * 24 * 30, // cookie duration
+        //       secure: false, // if value is false "https" is NOT required
+        //       sameSite: 'none', // if "none" the cookie is available on all domains insert in "domain" value.
+        //                            Otherwise the cookie is available only on the current domain
+        //     }
+        //   );
+        // }
+      }
+      /**
+       * This ‘identify’ call is only made if the user
+       * is landing on the portal from the showcase site.
+       * Only in this case does it have the device_id in the cookies
+       */
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      if (DEVICE_ID && IS_SUBDOMAIN && !(window as any).mixPanelIdentify) {
+        mixpanel.identify(DEVICE_ID);
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any, functional/immutable-data
+        (window as any).mixPanelIdentify = true;
+      }
     }
   }
 };


### PR DESCRIPTION
## Short description
In order to integrate the `identify` (from mixpanel SDK) to unify the data collected in the main domain with the data to be collected in the sub-domain (using the device_id passed as string in cookies section). 
In this PR, the identify call was integrated and the existing logic calling init was modified because it was called too many times. 

## List of changes proposed in this pull request
- Fix logic about mixpanel.init
- Add logic to call mixpanel.identify()
- update tests

## Demo
| Video Instruction |
| - | 
| <video src="https://github.com/user-attachments/assets/70c23b87-b4f2-42fc-85ae-db65291df6d6"/> |

| Mixpanel Board |
| - |
| <video src="https://github.com/user-attachments/assets/4dfbc191-edab-4692-93dc-a25e8ce3b06d"/>

## How to test
As you can see from the video you need to test this feature in a improper way (using same project switched on two localhost, you can follow the instructions [here](https://github.com/pagopa/io-web-profile/pull/181))
1. in .env file set `NEXT_PUBLIC_ANALYTICS_MOCK` as false, `NEXT_PUBLIC_DEV_MODE` as true, `NEXT_PUBLIC_IS_ACCOUNT_SUBDOMAIN` as true
2. run the application on the main localhost 
3. copy MP `device_id` from the mixpanel API into the cookie and set the domain as sub.localhost (or the name of your local subdomain)
4. Execute something in order to recall some MP event 
5. Change the domain and follow the same instructions. 
6. If you navigate on MP board you will se the correct data on the board



