### PR TITLE
[IOPID-2655] add IS_IOWEB super property

### DIFF
--- a/src/app/[locale]/_utils/mixpanel.ts
+++ b/src/app/[locale]/_utils/mixpanel.ts
@@ -26,6 +26,21 @@ export interface EventProperties {
   event_category?: EventCategory;
   [key: string]: unknown;
 }
+// eslint-disable-next-line prefer-const, @typescript-eslint/no-unused-vars
+let mockSuperProperties: Record<string, unknown> = {};
+
+const addIsIoWebSuperProperty = () => {
+  if (ANALYTICS_MOCK) {
+    mockSuperProperties = {
+      ...mockSuperProperties,
+      IS_IOWEB: true,
+    };
+  } else {
+    mixpanel.register({
+      IS_IOWEB: true,
+    });
+  }
+};
 
 /** To call in order to start the analytics service, otherwise no event will be sent */
 export const initAnalytics = (): void => {
@@ -43,6 +58,9 @@ export const initAnalytics = (): void => {
         debug: ANALYTICS_DEBUG,
       });
     }
+    // In order the IS_IOWEB super property setted in every moment
+    // and in every event is better call this function after the init
+    addIsIoWebSuperProperty();
   }
 };
 
@@ -62,7 +80,7 @@ export const trackEvent = (
   if (ANALYTICS_ENABLE && (window as any).initMixPanel && hasConsent()) {
     if (ANALYTICS_MOCK) {
       // eslint-disable-next-line no-console
-      console.log(event_name, properties);
+      console.log(event_name, { ...mockSuperProperties, ...properties });
       if (callback) {
         callback();
       }


### PR DESCRIPTION
## Short description
In this PR, the super property IS_IOWEB was added to track that we are on the subdomain on Mixpanel. 
In addition to the function to add the super property, logic has also been added to handle the mock of the super property locally when NEXT_PUBLIC_ANALYTICS_MOCK is set to true 

## DEMO
<details><summary>Tracking when NEXT_PUBLIC_ANALYTICS_MOCK is true (only locally tracking)</summary>
<p>

| Demo | 
| - | 
| <video src="https://github.com/user-attachments/assets/8e9f3ad1-326c-4f40-8ce4-dd411d3a42a9"/> |

</p>
</details>

<details><summary>Tracking when NEXT_PUBLIC_ANALYTICS_MOCK is false</summary>
<p>

| Tracking when NEXT_PUBLIC_ANALYTICS_MOCK is false | MP board | 
| - | - |
| <video src="https://github.com/user-attachments/assets/e898514c-8b84-4440-9db5-0a9cdbfab72a"/> | <video src="https://github.com/user-attachments/assets/af31373f-6e13-4d9a-86c1-dc4f220f3a47"/> |

</p>
</details>

## How to test
1. ensure that the values in the .env files for NEXT_PUBLIC_ANALYTICS_ENABLE and NEXT_PUBLIC_DEV_MODE are set to true. 
2. run the application 
3. run the tests as you see in the devo (assigning the value true or false depending on the test you are running to the variable in the NEXT_PUBLIC_ANALYTICS_MOCK .env file)