### PR TITLE
[IOPID-2678] Make workaround working in reverse

### DIFF
--- a/src/app/[locale]/(pages)/accedi/page.tsx
+++ b/src/app/[locale]/(pages)/accedi/page.tsx
@@ -39,17 +39,17 @@ const Access = (): React.ReactElement => {
 
       // Check if the current origin is "https://ioapp.it" or "http://localhost:3000"
       switch (url.origin) {
-        case 'https://ioapp.it':
+        case 'https://account.ioapp.it':
           // If the origin is the production domain, replace it with "account.ioapp.it"
           // eslint-disable-next-line functional/immutable-data
-          url.host = 'account.ioapp.it';
+          url.host = 'ioapp.it';
           // Reassign the modified URL, which triggers a redirect to the new URL
           window.location.assign(url.href);
           break;
-        case 'http://localhost:3000':
+        case 'http://sub.localhost:3000':
           // If the origin is localhost, replace it with "sub.localhost:3000" (testing scenario)
           // eslint-disable-next-line functional/immutable-data
-          url.host = 'sub.localhost:3000';
+          url.host = 'localhost:3000';
           // Reassign the modified URL, which triggers a redirect to the new URL
           window.location.assign(url.href);
           break;

--- a/src/app/[locale]/(pages)/accedi/page.tsx
+++ b/src/app/[locale]/(pages)/accedi/page.tsx
@@ -37,17 +37,17 @@ const Access = (): React.ReactElement => {
       // Create a URL object to safely manipulate the URL components
       const url = new URL(currentUrl);
 
-      // Check if the current origin is "https://ioapp.it" or "http://localhost:3000"
+      // Check if the current origin is "https://account.ioapp.it" or "http://sub.localhost:3000"
       switch (url.origin) {
         case 'https://account.ioapp.it':
-          // If the origin is the production domain, replace it with "account.ioapp.it"
+          // If the origin is the production domain, replace it with "ioapp.it"
           // eslint-disable-next-line functional/immutable-data
           url.host = 'ioapp.it';
           // Reassign the modified URL, which triggers a redirect to the new URL
           window.location.assign(url.href);
           break;
         case 'http://sub.localhost:3000':
-          // If the origin is localhost, replace it with "sub.localhost:3000" (testing scenario)
+          // If the origin is localhost, replace it with "localhost:3000" (testing scenario)
           // eslint-disable-next-line functional/immutable-data
           url.host = 'localhost:3000';
           // Reassign the modified URL, which triggers a redirect to the new URL


### PR DESCRIPTION
> [!Warning]
> This PR can be merged on **February 7, 2025** when the `hub-spid-login` switch will be executed

## Short description
This PR reverses the operation of the current workaround because once the switch of domains to hub-spid-login is done there will be a need to do the redirect in reverse than now when posing this case history

## How to test
1. Set your local alias to simulate subdomain into the file `/etc/hosts`
2. In hub-spid-login .env file change the endpoint success and error using your subdomain localhost alias
3. run the application
4. test as you can see from the video demo (both localhost primary domain and subdomain)

## Demo

https://github.com/user-attachments/assets/8f9636ec-0a33-48e0-bad7-f7c5645ca91d


