### PR TITLE
[IOPID-2657] Deleted the logics to manage both domains 

### DIFF
--- a/src/app/[locale]/(pages)/accedi/page.tsx
+++ b/src/app/[locale]/(pages)/accedi/page.tsx
@@ -38,34 +38,32 @@ const Access = (): React.ReactElement => {
     if (token && userFromToken && localeFromStorage) {
       storageTokenOps.write(token);
       storageUserOps.write(userFromToken);
-      if (loginInfo) {
-        trackEvent('IO_LOGIN_SUCCESS', {
-          SPID_IDP_ID: loginInfo.idpId,
-          SPID_IDP_NAME: loginInfo.idpName,
-          Flow: getLoginFlow(loginInfo),
-          event_category: 'TECH',
-        });
 
-        switch (getLoginFlow(loginInfo)) {
-          case FLOW_PARAMS.FLOW_SESSION_EXIT:
-            pushWithLocale(ROUTES.LOGOUT_CONFIRM);
-            break;
-          case FLOW_PARAMS.FLOW_PROFILE:
+      trackEvent('IO_LOGIN_SUCCESS', {
+        SPID_IDP_ID: loginInfo.idpId,
+        SPID_IDP_NAME: loginInfo.idpName,
+        Flow: getLoginFlow(loginInfo),
+        event_category: 'TECH',
+      });
+
+      switch (getLoginFlow(loginInfo)) {
+        case FLOW_PARAMS.FLOW_SESSION_EXIT:
+          pushWithLocale(ROUTES.LOGOUT_CONFIRM);
+          break;
+        case FLOW_PARAMS.FLOW_PROFILE:
+          pushWithLocale(ROUTES.PROFILE);
+          break;
+        case FLOW_PARAMS.FLOW_UNLOCK_ACCESS_L3:
+        case FLOW_PARAMS.FLOW_UNLOCK_ACCESS_L2:
+          if (checkElevationIntegrity()) {
+            pushWithLocale(ROUTES.PROFILE_RESTORE);
+          } else {
             pushWithLocale(ROUTES.PROFILE);
-            break;
-          case FLOW_PARAMS.FLOW_UNLOCK_ACCESS_L3:
-          case FLOW_PARAMS.FLOW_UNLOCK_ACCESS_L2:
-            if (checkElevationIntegrity()) {
-              pushWithLocale(ROUTES.PROFILE_RESTORE);
-            } else {
-              pushWithLocale(ROUTES.PROFILE);
-            }
-            break;
-        }
+          }
+          break;
       }
-      pushWithLocale(ROUTES.ERROR);
+      storageLoginInfoOps.delete();
     }
-    storageLoginInfoOps.delete();
   }, [loginInfo, pushWithLocale, token, userFromToken]);
 
   const handleLogoutBtn = () => {

--- a/src/app/[locale]/(pages)/accedi/page.tsx
+++ b/src/app/[locale]/(pages)/accedi/page.tsx
@@ -3,7 +3,7 @@ import { Box, Button, Card, CardContent, Divider, Grid, Typography, Link } from 
 import { CieIcon } from '@pagopa/mui-italia/dist/icons/CieIcon';
 import { SpidIcon } from '@pagopa/mui-italia/dist/icons/SpidIcon';
 import { useTranslations } from 'next-intl';
-import { useCallback, useEffect, useState } from 'react';
+import { useEffect, useState } from 'react';
 import { SpidLevels } from '../../_component/selectIdp/idpList';
 import { SelectIdp } from '../../_component/selectIdp/selectIdp';
 import useLocalePush from '../../_hooks/useLocalePush';
@@ -27,41 +27,6 @@ const Access = (): React.ReactElement => {
   const token = isBrowser() ? extractToken() : undefined;
   const userFromToken = token && parseJwt(token) ? userFromJwtToken(token) : undefined;
   const loginInfo = storageLoginInfoOps.read();
-
-  // Function to replace the origin and redirect the user to the modified URL
-  const replaceOriginAndRedirect = useCallback(() => {
-    // Retrieve the current URL from the browser window
-    const currentUrl = window.location.href;
-
-    try {
-      // Create a URL object to safely manipulate the URL components
-      const url = new URL(currentUrl);
-
-      // Check if the current origin is "https://account.ioapp.it" or "http://sub.localhost:3000"
-      switch (url.origin) {
-        case 'https://account.ioapp.it':
-          // If the origin is the production domain, replace it with "ioapp.it"
-          // eslint-disable-next-line functional/immutable-data
-          url.host = 'ioapp.it';
-          // Reassign the modified URL, which triggers a redirect to the new URL
-          window.location.assign(url.href);
-          break;
-        case 'http://sub.localhost:3000':
-          // If the origin is localhost, replace it with "localhost:3000" (testing scenario)
-          // eslint-disable-next-line functional/immutable-data
-          url.host = 'localhost:3000';
-          // Reassign the modified URL, which triggers a redirect to the new URL
-          window.location.assign(url.href);
-          break;
-        default:
-          pushWithLocale(ROUTES.ERROR);
-      }
-    } catch (error) {
-      // Handle any errors that may occur during URL manipulation
-      pushWithLocale(ROUTES.ERROR); // Redirect to the error route
-      console.error('Error while manipulating the URL:', error);
-    }
-  }, [pushWithLocale]);
 
   useEffect(() => {
     if (isBrowser()) {
@@ -97,13 +62,11 @@ const Access = (): React.ReactElement => {
             }
             break;
         }
-      } else {
-        // TODO: delete after domain switch. This is a wokaround.
-        replaceOriginAndRedirect();
       }
+      pushWithLocale(ROUTES.ERROR);
     }
     storageLoginInfoOps.delete();
-  }, [loginInfo, pushWithLocale, replaceOriginAndRedirect, token, userFromToken]);
+  }, [loginInfo, pushWithLocale, token, userFromToken]);
 
   const handleLogoutBtn = () => {
     trackEvent('IO_SESSION_EXIT_START', { event_category: 'UX', event_type: 'action' });

--- a/src/app/[locale]/(pages)/blocco-accesso/operazione-completata/page.tsx
+++ b/src/app/[locale]/(pages)/blocco-accesso/operazione-completata/page.tsx
@@ -10,7 +10,7 @@ import { Introduction } from '../../../_component/introduction/introduction';
 import { isIdpKnown } from '../../../_utils/idps';
 import { ROUTES } from '../../../_utils/routes';
 import { commonBackgroundLight } from '../../../_utils/styles';
-import { addSpacesEvery3Chars, isEnvConfigEnabled } from '@/app/[locale]/_utils/common';
+import { addSpacesEvery3Chars, BASE_URL } from '@/app/[locale]/_utils/common';
 import useLocalePush from '@/app/[locale]/_hooks/useLocalePush';
 import { unlockCodeSelector } from '@/app/[locale]/_redux/slices/blockAccessSlice';
 import { trackEvent } from '@/app/[locale]/_utils/mixpanel';
@@ -18,18 +18,15 @@ import {
   ListComponent,
   ListItemComponent,
 } from '@/app/[locale]/_component/listComponents/ListComponents';
-import { domainUrl } from '@/app/[locale]/_component/footer/footer';
 
 const unlockioaccessRich = {
   strong: (chunks: React.ReactNode) => <strong>{chunks}</strong>,
   ul: (chunks: React.ReactNode) => <ListComponent chunks={chunks} marginBottom="40px" />,
   li: (chunks: React.ReactNode) => <ListItemComponent chunks={chunks} />,
   //TODO: delete this code when the portal switch is finished
-  domain: isEnvConfigEnabled(process.env.NEXT_PUBLIC_IS_ACCOUNT_SUBDOMAIN)
-    ? 'account.ioapp.it'
-    : 'ioapp.it',
+  domain: BASE_URL,
   u: (chunks: React.ReactNode) => (
-    <Link target="_blank" fontWeight={600} href={domainUrl} color="textPrimary">
+    <Link target="_blank" fontWeight={600} href={BASE_URL} color="textPrimary">
       {chunks}
     </Link>
   ),

--- a/src/app/[locale]/_component/footer/footer.tsx
+++ b/src/app/[locale]/_component/footer/footer.tsx
@@ -8,7 +8,7 @@ import {
 import { useTranslations } from 'next-intl';
 import useLogin from '../../_hooks/useLogin';
 import { ROUTES } from '../../_utils/routes';
-import { isBrowser, isEnvConfigEnabled, localeFromStorage } from '../../_utils/common';
+import { BASE_URL, localeFromStorage } from '../../_utils/common';
 import { LANGUAGES, pagoPALink } from './footerConfig';
 
 type IOFooterProps = {
@@ -18,10 +18,6 @@ type IOFooterProps = {
 declare const OneTrust: {
   ToggleInfoDisplay: () => void;
 };
-
-export const domainUrl = isEnvConfigEnabled(process.env.NEXT_PUBLIC_IS_ACCOUNT_SUBDOMAIN)
-  ? 'https://account.ioapp.it'
-  : 'https://ioapp.it';
 
 export default function Footer({ onExit = exitAction => exitAction() }: IOFooterProps) {
   const t = useTranslations('ioesco.commonfooter');
@@ -34,7 +30,6 @@ export default function Footer({ onExit = exitAction => exitAction() }: IOFooter
   const socialAriaLabel = (social: string) => `Link: Vai al sito ${social} di PagoPA S.p.A.`;
   const productListUrl = process.env.NEXT_PUBLIC_FOOTER_PRODUCT_LIST;
 
-  const baseUrl = isBrowser() ? window.location.origin : domainUrl;
   const preLoginLinks: PreLoginFooterLinksType = {
     // First column
     aboutUs: {
@@ -76,7 +71,7 @@ export default function Footer({ onExit = exitAction => exitAction() }: IOFooter
           ariaLabel: ariaLabel('privacypolicy'),
           linkType: 'internal',
           onClick: () =>
-            window.open(`${baseUrl}/${localeFromStorage}${ROUTES.PRIVACY_POLICY}`, '_blank'),
+            window.open(`${BASE_URL}/${localeFromStorage}${ROUTES.PRIVACY_POLICY}`, '_blank'),
         },
         {
           label: t('cookiesperefercies'),
@@ -185,7 +180,7 @@ export default function Footer({ onExit = exitAction => exitAction() }: IOFooter
       ariaLabel: ariaLabel('privacypolicy'),
       linkType: 'internal',
       onClick: () =>
-        window.open(`${baseUrl}/${localeFromStorage}${ROUTES.PRIVACY_POLICY}`, '_blank'),
+        window.open(`${BASE_URL}/${localeFromStorage}${ROUTES.PRIVACY_POLICY}`, '_blank'),
     },
     {
       label: t('cookiesperefercies'),

--- a/src/app/[locale]/_utils/common.ts
+++ b/src/app/[locale]/_utils/common.ts
@@ -104,14 +104,13 @@ export const goTo = (route: string, timeout: number): void => {
 
 export const backToIo = (timeout: number): void => {
   window.setTimeout(
-    () =>
-      window.location.assign(
-        `${process.env.NEXT_PUBLIC_GOTO_IO_URL}`
-      ),
+    () => window.location.assign(`${process.env.NEXT_PUBLIC_GOTO_IO_URL}`),
     timeout
   );
 };
 
 export const weAreOnEmailValidationFlow = (pathName: string): boolean => {
-  return EMAIL_VALIDATION_ROUTES.includes(pathName)
-}
+  return EMAIL_VALIDATION_ROUTES.includes(pathName);
+};
+
+export const BASE_URL = 'https://account.ioapp.it';


### PR DESCRIPTION
> [!Warning]
> This PR can be merged after February 19, which is when we will no longer have the coexistence of the project on the ioapp.it domain and the account.ioapp.it domain

## Short description
In this PR, the logics that managed the coexistence of the project on both the ioapp.it domain and the account.ioapp.it subdomain were eliminated. After this PR only navigation will be allowed on the main domain account.ioapp.it.

## List of changes proposed in this pull request
- Removed the workaround for managing the redirect to ioapp.it at login 
- Removed the domain switch logic on links

## Demo

| Principal domain | Other Domain | 
| - | - |
| <video src="https://github.com/user-attachments/assets/f32ddac3-0050-4602-bfc1-0ffd89b38e49"/> | <video src="https://github.com/user-attachments/assets/04bc88c7-4a87-4dc1-bcbd-14ee9c7069b9"/> |

## How to test
Run the application and follow the video instructions
