### PR TITLE
chore: [IOAPPX-000] bump yarn-cache action to 4.2.0

### DIFF
--- a/.github/actions/setup-composite/action.yml
+++ b/.github/actions/setup-composite/action.yml
@@ -11,7 +11,7 @@ runs:
       run: echo "dir=$(yarn cache dir)" >> $GITHUB_OUTPUT
       shell: bash
     - id: yarn-cache
-      uses: actions/cache@88522ab9f39a2ea568f7027eddc7d8d8bc9d59c8 # v3.3.1
+      uses: actions/cache@1bd1e32a3bdc45362d1e726936510720a7c30a57 # v4.2.0
       env:
         cache-name: cache-node-modules
       with:


### PR DESCRIPTION
## Short description

Bump yarn-cache action to `4.2.0`
